### PR TITLE
Fix for external link color issue

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,7 +5,6 @@ last 1 major version
 not dead
 Chrome >= 60
 Firefox >= 60
-Edge >= 16
 iOS >= 10
 Safari >= 10
 Android >= 6

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     versioning-strategy: increase
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,8 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  schedule:
-    - cron: '20 11 * * 4'
 
 jobs:
   analyze:
@@ -27,12 +25,12 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/assets/styles/_article.scss
+++ b/assets/styles/_article.scss
@@ -41,7 +41,7 @@ article a:not(.stretched-link)[href^="http"]::after {
   width: 11px;
   height: 11px;
   margin-left: 4px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='#0c77be' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
   background-position: center;
   background-repeat: no-repeat;
   background-size: contain;

--- a/content/components/autocomplete.md
+++ b/content/components/autocomplete.md
@@ -5,6 +5,7 @@ description: "The autocomplete is a text input field enhanced by a panel of sugg
 images:
   - "/img/headers/components/autocomplete.png"
 components: true
+keywords: typeahead
 aliases:
   - "/elements/autocomplete/"
 contributors: ""

--- a/layouts/_default/components.html
+++ b/layouts/_default/components.html
@@ -23,8 +23,13 @@
       <div class="col">
         <form class="w-100 mb-2">
           <label for="search" class="sr-only">Search for components</label>
+          <div class="input-with-icon-left">
           <input class="form-control form-control-lg w-100 search" id="search" placeholder="Start typing to filter..."
-            inputmode="search" autocomplete="off" title="" onkeypress="return event.keyCode!=13">
+            type="search" autocomplete="off" title="" onkeypress="return event.keyCode!=13">
+            <div class="input-icon">
+              <i class="modus-icon material-icons">search</i>
+            </div>
+            </div>
         </form>
       </div>
     </div>


### PR DESCRIPTION
Fixes bug where external link icon isn't showing:
![image](https://user-images.githubusercontent.com/1212885/165084408-9cc6425c-8c5d-4463-9e35-c7200ca6fb5f.png)
(caused by the hex value not being escaped correctly)


also:
- update Dependabot config
- minor UI optimization for component search
- only run CodeQL analysis on PRs - not every day
- Remove Legacy Edge from `browserlist` config (not supported)