### PR TITLE
post-launch CSS fixes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
+  "bracketSameLine": true,
   "printWidth": 280
 }

--- a/assets/styles/_tables.scss
+++ b/assets/styles/_tables.scss
@@ -6,3 +6,7 @@
   max-width: 79px;
   width: 79px;
 }
+
+.table.table-bordered thead {
+  background-color: rgba(133, 133, 133, 0.1);
+}

--- a/assets/styles/_theme-dark.scss
+++ b/assets/styles/_theme-dark.scss
@@ -63,4 +63,12 @@
   .btn .spinner-border {
     color: #fff;
   }
+
+  .table.table-bordered {
+    background-color: #171c1e;
+  }
+
+  .card-blog-brief .card-header img {
+    filter: invert(1) brightness(111%);
+  }
 }

--- a/assets/styles/styles.scss
+++ b/assets/styles/styles.scss
@@ -1,4 +1,3 @@
-@import "anatomy-css";
 @import "theme-toggle";
 @import "theme-light";
 @import "theme-dark";
@@ -28,6 +27,7 @@
 @import "footer";
 @import "utilities";
 @import "was-this-page-helpful";
+@import "anatomy-css";
 
 // underline links
 a {

--- a/content/community-contribution-process.md
+++ b/content/community-contribution-process.md
@@ -7,6 +7,12 @@ community: true
 hideToc: true
 ---
 
+<style>
+article img {
+  background-color: #fff;
+}
+</style>
+
 The Modus team is dedicated to maintaining a consistent, top-quality product. Accordingly, before any component is revised or added, it goes through a process of reviews and approvals.
 
 ![Contribution Process](/img/guide/contribution-process.png)

--- a/content/components/alerts.md
+++ b/content/components/alerts.md
@@ -22,7 +22,7 @@ Alerts display in direct response to a user action (e.g. clicking the Submit but
 
 - Providing a user contextual information or status of an action they’re trying to complete in a specific element on the visible page.
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th scope="col">Example</th>

--- a/content/components/badges.md
+++ b/content/components/badges.md
@@ -115,7 +115,7 @@ Badges can be inserted into other elements.
 - Badges should be centered vertically inside of their containing element.
 - Font weight: 700
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th></th>

--- a/content/components/buttons.md
+++ b/content/components/buttons.md
@@ -42,7 +42,7 @@ There are two button progressions you can choose from: structural and color prog
 
 ### Structural Progression
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Example</th>
@@ -88,7 +88,7 @@ There are two button progressions you can choose from: structural and color prog
 
 ### Color Progression
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Example</th>
@@ -135,7 +135,7 @@ There are two button progressions you can choose from: structural and color prog
 
 ### Ancillary Buttons
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Type</th>
@@ -205,7 +205,7 @@ There are two button progressions you can choose from: structural and color prog
 - If using multiple buttons, label them distinctly.
 - The size of the buttons should be used in proportion to the context and content around it.
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th></th>
@@ -268,7 +268,7 @@ All buttons (including icon buttons) should have the following states:
 
 #### Structural Progression States
 
-<table class="table table-bordered bg-white" style="width: max-content">
+<table class="table table-bordered" style="width: max-content">
       <thead class="thead-light">
         <tr>
           <th>State</th>
@@ -328,7 +328,7 @@ All buttons (including icon buttons) should have the following states:
 
 #### Color Progression States
 
-<table class="table table-bordered bg-white" style="width: max-content">
+<table class="table table-bordered" style="width: max-content">
       <thead class="thead-light">
         <tr>
           <th>State</th>
@@ -388,7 +388,7 @@ All buttons (including icon buttons) should have the following states:
 
 #### Auxiliary Button States
 
-<table class="table table-bordered bg-white" style="width: max-content">
+<table class="table table-bordered" style="width: max-content">
       <thead class="thead-light">
         <tr>
           <th>State</th>

--- a/content/components/cards.md
+++ b/content/components/cards.md
@@ -61,7 +61,7 @@ A Card may contain any of the following elements (with the minimum of one), but 
 - Card dimensions are based on its content and the container in which it resides.
 - Apply custom heights and width to meet product requirements.
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <tr>
     <td width="50%">
     <img src="/img/guide/card_04.png" alt="" width="372" height="338" class="img-fluid" loading="lazy">

--- a/content/components/checkboxes.md
+++ b/content/components/checkboxes.md
@@ -103,7 +103,7 @@ Checkboxes should be used in forms that require submission and processing. The c
 - Enabling selection of an object, such as a [Card](/components/cards/).
 - Affording selection of a row within a data [Table](/components/tables/).
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <tbody>
     <thead class="thead-light">
       <tr>
@@ -184,7 +184,7 @@ Checkboxes should be used in forms that require submission and processing. The c
 - Checking or unchecking elicits an immediate change in the UI or functionality, such as enabling a disabled field or revealing more controls. Instead, use a [Switch](/components/switches/).
 - Checking or unchecking elicits a change in background functionality without affecting the UI, like disabling an email notification. Instead, use a [Switch](/components/switches/).
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <tbody>
     <tr>
       <td scope="row">

--- a/content/components/content-tree.md
+++ b/content/components/content-tree.md
@@ -66,7 +66,7 @@ A content tree view is text-only by default. This option is best used when a hie
 
 <img src="/img/tree-item-states.svg" class="img-fluid bg-light" width="792" height="751" loading="lazy" alt="Tree Item States"></br>
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>State</th>

--- a/content/components/inputs.md
+++ b/content/components/inputs.md
@@ -88,7 +88,7 @@ There are two sizes of input fields defined:
 - Default: default form inputs should have a height of 32px (8px padding) and a font-size of 12px (.75rem). Used for most forms.
 - Large: larger variant should have a height of 48px (16px padding) and a font-size of 14px (.875rem). Used for forms in in-cab applications
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th></th>
@@ -200,7 +200,7 @@ There are two sizes of input fields defined:
 - Default: used for most forms
 - Large: used for forms in in-cab applications
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th></th>

--- a/content/components/navbar.md
+++ b/content/components/navbar.md
@@ -76,7 +76,7 @@ Navbar background color can be white or Trimble Dark Blue.
 
 ![Framework](/img/app-header-framework.svg)
 
-<table class="table table-bordered bg-white" style="width: max-content">
+<table class="table table-bordered" style="width: max-content">
       <thead class="thead-light">
         <tr>
           <th>Element</th>
@@ -123,7 +123,7 @@ Navbar background color can be white or Trimble Dark Blue.
 - Elements should be vertically-centered within the header.
 - Icon areas starting from the Profile avatar are flush against each other.
 
-<table class="table table-bordered bg-white" style="width: max-content">
+<table class="table table-bordered" style="width: max-content">
       <tbody>
         <tr>
           <td>X-Small (320px) breakpoint</td>

--- a/content/components/pagination.md
+++ b/content/components/pagination.md
@@ -30,7 +30,7 @@ Pagination allows the user to easily find and navigate through large amounts of 
 
 ## Specifications
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th></th>

--- a/content/components/side-navigation.md
+++ b/content/components/side-navigation.md
@@ -97,7 +97,7 @@ There are two color options available. They can be used in the following combina
 
 ![White and Blue Navigation](/img/sidenav-states-3.png)
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th></th>
@@ -141,7 +141,7 @@ There are two color options available. They can be used in the following combina
 
 ### Padding and Spacing
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Class</th>
@@ -197,7 +197,7 @@ There are two color options available. They can be used in the following combina
 
 ### Typography
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Class</th>
@@ -254,7 +254,7 @@ There are two color options available. They can be used in the following combina
 
 #### Responsiveness
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Breakpoint</th>

--- a/content/components/spinners.md
+++ b/content/components/spinners.md
@@ -36,8 +36,7 @@ Spinners are used as indeterminate progress indicators to show the user that the
     <button type="button" class="btn btn-primary display-active">
       <span
         class="spinner-border mr-1"
-        style="height: 16px; width: 16px;"
-      ></span>
+        style="height: 16px; width: 16px; color: #fff"></span>
       Loading
     </button>
   </div>

--- a/content/components/switches.md
+++ b/content/components/switches.md
@@ -44,7 +44,7 @@ Switches are selection controls that yield instantaneous actions. They have an o
 - Toggling elicits a change in background behavior without affecting the UI.
 - You want to trigger a state change directly when you toggle it.
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th scope="col">Example</th>
@@ -137,7 +137,7 @@ Switches are selection controls that yield instantaneous actions. They have an o
 - Requesting multiple choices from a group of options. Instead, use a [Checkbox](/components/checkboxes/) group.
 - Users need to select one item from a list of options. Instead, use a [Radio Button](/components/radio-buttons/).
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <tbody>
     <tr>
       <td scope="row">
@@ -207,9 +207,9 @@ Switches are selection controls that yield instantaneous actions. They have an o
 
 - Avoid changing the label text based on on and off state.
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <tr>
-    <td>
+    <td width="50%">
       <div class="custom-control custom-switch">
         <input
           type="checkbox"

--- a/content/components/tables.md
+++ b/content/components/tables.md
@@ -34,7 +34,7 @@ Tables are ideal for displaying data in rows and columns. They organize informat
 
 ### Typography
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Class</th>
@@ -79,7 +79,7 @@ Follow these rules, when aligning alphanumeric and numeric input types in a colu
 
 ### Structure
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Class</th>
@@ -113,7 +113,7 @@ Follow these rules, when aligning alphanumeric and numeric input types in a colu
 
 ### Background Color
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Class</th>

--- a/content/components/tabs.md
+++ b/content/components/tabs.md
@@ -23,7 +23,7 @@ Tabs are a set of layered sections of content, known as tab panels, that display
 - You want to organize content into meaningful sections that occupy less screen space.
 - Add visual consistency.
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <tr>
     <td>
       <ul class="nav nav-tabs" id="myTab" role="tablist">

--- a/content/components/toasts.md
+++ b/content/components/toasts.md
@@ -25,7 +25,7 @@ Toasts display low priority, event-driven feedback which usually doesn’t requi
 - Confirming the success of a global action.
 - Displaying quick snippets of information that disappear on their own after a set amount of time has passed.
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th scope="col">Example</th>

--- a/content/foundations-color-palette.md
+++ b/content/foundations-color-palette.md
@@ -203,7 +203,7 @@ Green Pale
 
 ## Text Color Use Examples
 
-![Text Color](/img/text-color.svg)
+<img src="/img/text-color.svg" class="img-fluid text-center mx-auto mb-4" width="670" alt="Text Color Palette" style="background:#fff">
 
 <!--## Download Swatch Files
 

--- a/content/foundations-icon-definitions.md
+++ b/content/foundations-icon-definitions.md
@@ -66,7 +66,7 @@ The cornerstones of consistent icons:
 
 There are a few options for icon sizes that you can choose based on your product, the context in which they are used, digital platform, and/ or user preferences. Use no more than 2-3 sizes in one application.
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Canvas Size/ Icon Size</th>
@@ -90,10 +90,10 @@ There are a few options for icon sizes that you can choose based on your product
       <td>1-2px</td>
       <td>&nbsp;</td>
     </tr>
-    <tr style="background-color: #CFE1EE">
+    <tr>
       <td scope="row"><strong>32x32px</strong></td>
-      <td>2px</td>
-      <td>Primary icon size</td>
+      <td><strong>2px</strong></td>
+      <td><strong>Primary icon size</strong></td>
     </tr>
     <tr>
       <td scope="row">48x48px</td>
@@ -189,7 +189,7 @@ In web and mobile applications, icons can have subtle transitions when changing 
 
 ## Icon File Formats
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
   <thead class="thead-light">
     <tr>
       <th>Technology</th>

--- a/content/foundations-shadows-and-depth.md
+++ b/content/foundations-shadows-and-depth.md
@@ -68,41 +68,16 @@ Standard drop shadow color is gray. Always adjust color opacity to retain a maxi
 
 Z-index is a CSS property that specifies the stack order of an element. An element with greater stack order is always in front of an element with a lower stack order.
 
-<table class="table table-bordered bg-white">
-  <thead class="thead-light">
-    <tr>
-      <th>Z-index</th>
-      <th>Use</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td scope="row" class="font-weight-bold">1000</td>
-      <td>Dropdowns</td>
-    </tr>
-    <tr>
-      <td scope="row" class="font-weight-bold">1020</td>
-      <td>Sticky Elements</td>
-    </tr>
-    <tr>
-      <td scope="row" class="font-weight-bold">1030</td>
-      <td>Fixed Elements</td>
-    </tr>
-    <tr>
-      <td scope="row" class="font-weight-bold">1040</td>
-      <td>Modal Backdrops</td>
-    </tr>
-    <tr>
-      <td scope="row" class="font-weight-bold">1050</td>
-      <td>Modal Dialogs</td>
-    </tr>
-    <tr>
-      <td scope="row" class="font-weight-bold">1060</td>
-      <td>Popovers</td>
-    </tr>
-    <tr>
-      <td scope="row" class="font-weight-bold">1070</td>
-      <td>Tooltips</td>
-    </tr>
-  </tbody>
-</table>
+{{< table "table table-bordered" >}}
+
+| Z-index | Use             |
+| ------- | --------------- |
+| 1000    | Dropdowns       |
+| 1020    | Sticky Elements |
+| 1030    | Fixed Elements  |
+| 1040    | Modal Backdrops |
+| 1050    | Modal Dialogs   |
+| 1060    | Popovers        |
+| 1070    | Tooltips        |
+
+{{</ table >}}

--- a/content/foundations-typography.md
+++ b/content/foundations-typography.md
@@ -48,7 +48,7 @@ The variations help keep type styles to a minimum, so consistency is easier to a
 
 ### Web Applications
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
       <thead class="thead-light">
         <tr>
           <th>Category</th>
@@ -229,7 +229,7 @@ The variations help keep type styles to a minimum, so consistency is easier to a
 
 ### Mobile Application Scale
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
       <thead class="thead-light">
         <tr>
           <th>Category</th>
@@ -384,7 +384,7 @@ The variations help keep type styles to a minimum, so consistency is easier to a
 
 ### Desktop Applications Scale
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
       <thead class="thead-light">
         <tr>
           <th>Category</th>
@@ -575,7 +575,7 @@ The variations help keep type styles to a minimum, so consistency is easier to a
 
 ## Display Headings
 
-<table class="table table-bordered bg-white">
+<table class="table table-bordered">
       <thead class="thead-light">
         <tr>
           <th>Category</th>


### PR DESCRIPTION
Post-launch fixes including:

- tables in the docs were currently black background, (changed to same color as the footer ( #171c1e ))
- the icon in the spinner button wasn't white and it should be
- contribution process image should have white background
- fix for SVG icons in cards not showing in light gray
- remove unnecessary `bg-white` class from tables which caused issue in dark mode
