### PR TITLE
Fix for dark mode spinner label color

### DIFF
--- a/content/components/spinners.md
+++ b/content/components/spinners.md
@@ -49,10 +49,16 @@ Spinners are used as indeterminate progress indicators to show the user that the
 <div class="guide-example-block d-inline-block">
   <div class="guide-sample text-center text-primary">
     <div class="spinner-border"></div>
-    <div class="h1 text-primary mt-3">Loading...</div>
+    <div class="h2 text-primary mt-3">Loading...</div>
   </div>
 </div>
 
 ### Accessibility
 
 - Each spinner should include `role="status"` and a nested `<span class="sr-only">Loading...</span>`.
+
+<style>
+[data-theme="dark"] .guide-sample .h2 {
+  color: #fff !important;
+}
+</style>

--- a/content/foundations-dark-mode.md
+++ b/content/foundations-dark-mode.md
@@ -25,11 +25,11 @@ The overall idea behind Trimble components in dark mode can be categorized on hi
 
 ![Navbar example](/img/dark-mode-navbar.png)
 
-- A primary (highlight) Trimble Blue #019aeb is the main highlight color and affects the vast majority of controls where the user's attention is crucial, such as buttons, dropdown buttons, checkboxes, radio buttons, switches, etc. It is used for breadcrumbs and tabs text too. Here are few examples:
+- A primary (highlight) Trimble Blue {{< color-preview hex="#019aeb">}} is the main highlight color and affects the vast majority of controls where the user's attention is crucial, such as buttons, dropdown buttons, checkboxes, radio buttons, switches, etc. It is used for breadcrumbs and tabs text too. Here are few examples:
 
 ![Progress bar example](/img/dark-mode-progress-bar.png)
 
-- Components using red/yellow/green text in light mode follow a different design principle in dark mode. In dark mode, white text overlays a solid or semi-transparent red//yellow/green background instead to address readability constraints. Those are mainly alerts, toasts, and input messages. An example:
+- Components using red/yellow/green text in light mode follow a different design principle in dark mode. In dark mode, white text overlays a solid or semi-transparent red/yellow/green background instead to address readability constraints. Those are mainly alerts, toasts, and input messages. An example:
 
 ![Toasts example](/img/dark-mode-toasts.png)
 


### PR DESCRIPTION
## Description

Fix for dark mode spinner label color and two minor fixes for dark mode foundations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

locally with Edge v103 on Windows 10

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Existing tests pass locally with my changes


Screenshot of fix:
![image](https://user-images.githubusercontent.com/1212885/176619837-f602a548-401b-4dbd-8dc3-0ddf08c13f8d.png)
