### PR TITLE
Fix for display heading font sizes

### DIFF
--- a/assets/styles/_typography.scss
+++ b/assets/styles/_typography.scss
@@ -117,19 +117,19 @@ p[class^="desktop-"] {
 // #display-headings
 
 .display-h1 {
-  font-size: 72px;
+  font-size: 72px !important;
   letter-spacing: 0.4px;
   font-weight: 700;
 }
 
 .display-h2 {
-  font-size: 40px;
+  font-size: 40px !important;
   letter-spacing: 0.4px;
   font-weight: 700;
 }
 
 .display-h3 {
-  font-size: 32px;
+  font-size: 32px !important;
   letter-spacing: 0.283px;
   font-weight: 600;
 }


### PR DESCRIPTION
https://modus.trimble.com/foundations/typography/#display-headings

Display headings are not showing the correct size here. This PR fixes that.

FIX preview:
https://deploy-preview-169--modus-trimble.netlify.app/foundations/typography/#display-headings