### PR TITLE
a11y docs fixes for inputs, modals and progress bars

### DIFF
--- a/content/components/inputs.md
+++ b/content/components/inputs.md
@@ -54,8 +54,8 @@ Input fields or text fields allow users to enter text into a UI. They typically 
     </div>
   </div>
   <div class="form-group">
-    <label for="exampleFormControlSelect1">Custom Select Outlined</label>
-    <select class="custom-select form-control" id="exampleFormControlSelect2">
+    <label for="exampleFormControlSelect">Custom Select Outlined</label>
+    <select class="custom-select form-control" id="exampleFormControlSelect">
       <option>Option 1</option>
       <option>Option 2</option>
       <option>Option 3</option>
@@ -132,124 +132,6 @@ There are two sizes of input fields defined:
     </tr>
   </tbody>
 </table>
-
-<!--<hr>
-
-<form>
-  <div class="form-group">
-    <label for="Input1">Regular Input</label>
-    <input class="form-control border-secondary" id="Input1" placeholder="Placeholder Text">
-  </div>
-  <div class="form-group">
-    <label for="Input2">Input with icon on right</label>
-    <div class="input-with-icon-right">
-      <input class="form-control border-secondary" placeholder="Placeholder Text" id="Input2">
-      <div class="input-icon">
-        <i class="modus-icon material-icons">visibility</i>
-      </div>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label for="Input3">Input with icon on left</label>
-    <div class="input-with-icon-left">
-      <input class="form-control border-secondary" placeholder="Placeholder Text" id="Input3">
-      <div class="input-icon">
-        <i class="modus-icon material-icons">search</i>
-      </div>
-    </div>
-  </div>
-  <div class="form-group">
-    <label for="Input4">Input with a button</label>
-    <div class="input-group">
-      <input class="form-control border-secondary" placeholder="Placeholder Text" id="Input4">
-      <div class="input-group-append">
-        <button class="btn btn-outline-secondary">
-          Go
-        </button>
-      </div>
-    </div>
-  </div>
-  <div class="form-group">
-    <label for="exampleFormControlSelect1">Custom Select Outlined</label>
-    <select class="custom-select form-control border-secondary" id="exampleFormControlSelect2">
-      <option>Option 1</option>
-      <option>Option 2</option>
-      <option>Option 3</option>
-      <option>Option 4</option>
-      <option>Option 5</option>
-    </select>
-  </div>
-  <div class="form-group">
-  <label for="Input1">Normal Text Area</label>
-  <textarea class="form-control border-secondary" id="Input1">Some Text</textarea>
-</div>
-  <button type="submit" class="btn btn-primary">Submit</button>
-</form>
-
-## Specifications
-
-- Label Text Color: #6A6976
-- Input Text Color: #363545
-- Placeholder Text Color: #D0D0D7
-
-- 12px padding on both default and large
-
-There are two sizes of input fields defined:
-
-- Default: used for most forms
-- Large: used for forms in in-cab applications
-
-<table class="table table-bordered">
-  <thead class="thead-light">
-    <tr>
-      <th></th>
-      <th>Example</th>
-      <th>Height</th>
-      <th>Font Size</th>
-    </tr>
-  </thead>
-  <tbody>
-  <tr>
-      <th scope="row">Default</th>
-      <td class="anatomy-cell bg-light">
-        <input class="form-control mb-2" placeholder="Placeholder text" />
-        <input
-          class="form-control anatomy-display-static mb-5"
-          placeholder="Default Input"
-          value="Default Input"
-        />
-      </td>
-      <td>32px</td>
-      <td>12px (0.75 rem)</td>
-    </tr>
-    <tr>
-      <th scope="row">Large</th>
-      <td class="anatomy-cell bg-light">
-        <input
-          class="form-control form-control-lg mb-2"
-          placeholder="Placeholder text"
-        />
-        <input
-          class="form-control form-control-lg anatomy-display-static mb-5"
-          placeholder="Large Input"
-          value="Large Input"
-        />
-      </td>
-      <td>48px</td>
-      <td>14px (0.875 rem)</td>
-    </tr>
-  </tbody>
-</table>-->
-
-<!--### Textarea
-
-<table class="table table">
- <div class="form-group col-12 col-sm-6 col-md-4 pl-0">
-    <label for="exampleFormControlTextarea1">Example textarea</label>
-    <textarea class="form-control" id="exampleFormControlTextarea1" rows="3"></textarea>
-  </div>
-</table>-->
 
 ### Behaviors
 

--- a/content/components/modals.md
+++ b/content/components/modals.md
@@ -39,9 +39,9 @@ Both header and button container should be 64px in height.
 
 <div class="guide-example-block my-3 bg-light pr-n5">
   <div class="guide-content-sample modal-static" style="padding-bottom: 24px;">
-    <div class="modal show d-block ml-5 position-relative" tabindex="-1" role="dialog">
+    <div class="modal show d-block ml-5 position-relative" tabindex="-1" role="dialog" style="z-index:1">
       <div class="modal-dialog show" role="document">
-        <div class="modal-content" style="width: 80%; float: right;">
+        <div class="modal-content float-right" style="width: 80%;">
           <div class="modal-header anatomy-display-static" data-anatomy-colors="false" style="padding-top: 17px; padding-bottom: 18px;">
             <h4 class="modal-title">Modal Header</h4>
             <button

--- a/content/components/progress-bars.md
+++ b/content/components/progress-bars.md
@@ -38,6 +38,7 @@ Progress indicators inform users about the status of ongoing processes, such as 
         id="progressExample"
         class="progress-bar"
         role="progressbar"
+        aria-label="example progress bar"
         style="width: 0;"
         aria-valuenow="25"
         aria-valuemin="0"
@@ -58,6 +59,7 @@ Progress indicators inform users about the status of ongoing processes, such as 
       <div
         class="progress-bar"
         role="progressbar"
+        aria-label="example progress bar"
         style="width: 75%;"
         aria-valuenow="75"
         aria-valuemin="0"


### PR DESCRIPTION
Fixes for:

- duplicates IDs on input page
- z-index issue on modals made it appear above the navbar
- progress bar examples missing aria-label causing it to fail Lighthouse a117 audit. (https://googlechrome.github.io/lighthouse/viewer/?psiurl=https%3A%2F%2Fmodus.trimble.com%2Fcomponents%2Fprogress-bars%2F&strategy=desktop&category=accessibility&utm_source=lh-chrome-ext)