### PR TITLE
Remove unnecessary navbar from toasts example

### DIFF
--- a/content/components/toasts.md
+++ b/content/components/toasts.md
@@ -23,20 +23,13 @@ Toasts display low priority, event-driven feedback which usually doesn’t requi
 - Confirming the success of a global action.
 - Displaying quick snippets of information that disappear on their own after a set amount of time has passed.
 
+## Example
+
 <table class="table table-bordered">
-  <thead class="thead-light">
-    <tr>
-      <th scope="col">Example</th>
-    </tr>
-  </thead>
   <tbody>
     <tr>
       <td scope="row">
         <div class="border position-relative">
-          <div class="p-3 bg-primary d-flex">
-            <i class="material-icons" style="color: #fff;">menu</i>
-            <span class="h1 ml-3 mb-0" style="color: #fff;">App Title</span>
-          </div>
           <div class="p-3">
             <div class="list-group">
               <li class="list-group-item active list-item-left-control">

--- a/content/in-field/buttons.md
+++ b/content/in-field/buttons.md
@@ -3,7 +3,7 @@ title: "Buttons"
 layout: "single"
 description: "Info about in-field buttons"
 images:
-  - "/img/headers/components/buttons.png"
+  - "/img/components/headers/buttons.png"
 infield: true
 sitemap_exclude: true
 ---

--- a/content/mobile/accordions.md
+++ b/content/mobile/accordions.md
@@ -3,7 +3,7 @@ title: "Accordions"
 layout: "single"
 description: "The accordion element delivers large amounts of content in a small space through progressive disclosure." # this displays in header
 images:
-  - "/img/headers/components/accordions.png"
+  - "/img/components/headers/accordions.png"
 mobile: true
 sitemap_exclude: true # hides page from sitemap. set to true for pages you want to hide or don't want to promote
 ---


### PR DESCRIPTION
PR also fixes the image paths for two components images (used when sharing) 