### PR TITLE
Update Stats page

### DIFF
--- a/content/stats.md
+++ b/content/stats.md
@@ -14,7 +14,7 @@ hideToc: true
 <img alt="npm" class="mb-2 mr-2" src="https://img.shields.io/npm/dm/@trimbleinc/modus-bootstrap">
 
 - [npm Downloads](https://www.npmjs.com/package/@trimbleinc/modus-bootstrap)
-- [npm Download Stats](https://npm-stat.com/charts.html?package=%40trimbleinc%2Fmodus-bootstrap&from=2021-01-01&to=2022-02-06)
+- <a href="https://npm-stat.com/charts.html?package=%40trimbleinc%2Fmodus-bootstrap&from=2021-11-01&to={{< date-today >}}">npm Download Stats</a>
 - [CDN Downloads](https://www.jsdelivr.com/package/npm/@trimbleinc/modus-bootstrap)
 
 ## Modus React Bootstrap
@@ -25,7 +25,7 @@ hideToc: true
 <a href="https://github.com/trimble-oss/modus-react-bootstrap/forks"><img alt="GitHub forks" class="mb-2 mr-2"src="https://img.shields.io/github/forks/trimble-oss/modus-react-bootstrap"></a>
 
 - [npm Downloads](https://www.npmjs.com/package/@trimbleinc/modus-react-bootstrap)
-- [npm Download Stats](https://npm-stat.com/charts.html?package=%40trimbleinc%2Fmodus-react-bootstrap&from=2021-11-01&to=2022-02-06)
+- <a href="https://npm-stat.com/charts.html?package=%40trimbleinc%2Fmodus-react-bootstrap&from=2021-11-01&to={{< date-today >}}">npm Download Stats</a>
 - [CDN Downloads](https://www.jsdelivr.com/package/npm/@trimbleinc/modus-react-bootstrap)
 
 ## Modus Web Components
@@ -36,7 +36,7 @@ hideToc: true
 <a href="https://github.com/trimble-oss/modus-web-components/forks"><img alt="GitHub forks" class="mb-2 mr-2" src="https://img.shields.io/github/forks/trimble-oss/modus-web-components"></a>
 
 - [npm Downloads](https://www.npmjs.com/package/@trimble-oss/modus-web-components)
-- [npm Download Stats](https://npm-stat.com/charts.html?package=%40trimble-oss%2Fmodus-web-components&from=2021-11-01&to=2022-02-06)
+- <a href="https://npm-stat.com/charts.html?package=%40trimble-oss%2Fmodus-web-components&from=2021-11-01&to={{< date-today >}}">npm Download Stats</a>
 - [CDN Downloads](https://www.jsdelivr.com/package/npm/@trimble-oss/modus-web-components)
 
 <style>


### PR DESCRIPTION
Fix for: https://modus.trimble.com/stats/
Changes download stats page to automatically use latest date range.

PREVIEW:
https://wonderful-hill-0a9292110-243.centralus.1.azurestaticapps.net/stats/