### PR TITLE
This sets the right menu to active (bold) for components sections pages

### DIFF
--- a/content/components/in-field/overview/_index.md
+++ b/content/components/in-field/overview/_index.md
@@ -19,7 +19,7 @@ article .nav-tabs {
 }
 </style>
 
-{{< img src="/img/in-field/intro.png" width="1087" height="385" class="bg-light" lazyload="auto" >}}
+{{< img src="/img/in-field/intro.png" dark="/img/in-field/intro-dark.png" width="1087" height="385" class="w-100" lazyload="auto" >}}
 
 ## Overview
 

--- a/content/components/web/badges/_index.md
+++ b/content/components/web/badges/_index.md
@@ -110,69 +110,6 @@ Badges can be inserted into other elements.
   </div>
 </div>
 
-## Specifications
-
-- Badges come in 3 defined heights:
-  - **Small**: 14px
-  - **Default**: 20px
-  - **Large**: 28px
-- Badges should be centered vertically inside of their containing element.
-- Font weight: 700
-
-<table class="table table-bordered">
-  <thead class="thead-light">
-    <tr>
-      <th></th>
-      <th>Example</th>
-      <th>Height</th>
-      <th>Use Case</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">Small</th>
-      <td class="anatomy-cell">
-        <span
-          data-anatomy-colors="false"
-          class="badge badge-sm badge-primary anatomy-display-static"
-          >Badge</span
-        >
-      </td>
-      <td>14px</td>
-      <td>Inside lists or other elements</td>
-    </tr>
-    <tr>
-      <th scope="row">Default</th>
-      <td class="anatomy-cell">
-        <span
-          data-anatomy-colors="false"
-          class="badge badge-primary anatomy-display-static"
-          >Badge</span
-        >
-      </td>
-      <td>20px</td>
-      <td>Stand-alone or inside lists</td>
-    </tr>
-    <tr>
-      <th scope="row">Large</th>
-      <td class="anatomy-cell">
-        <span
-          data-anatomy-colors="false"
-          class="badge badge-lg badge-primary anatomy-display-static"
-          >Badge</span
-        >
-      </td>
-      <td>28px</td>
-      <td>Stand-alone for emphasis</td>
-    </tr>
-  </tbody>
-</table>
-
-### Accessibility
-
-- Badges may be confusing for users of screen readers and similar assistive technologies. While the styling of badges provides a visual cue as to their purpose, these users will simply be presented with the content of the badge. Ensure that information denoted by the color is either obvious from the content itself (e.g. the visible text), or is included through alternative means, such as additional hidden text.
-- When displaying a badge on any color other than white, make sure it meets [required contrast ratios](/foundations/accessibility/).
-
 {{< whats-changed-table >}}
 
 | Date       | Version | Notes                                                                          | Contributors                   |

--- a/content/components/web/chips/_index.md
+++ b/content/components/web/chips/_index.md
@@ -252,12 +252,6 @@ Input chips can be in any of the following states:
 - Tap a chip to select it.
 - Multiple chips can be selected or unselected.
 
-### Accessibility
-
-- Use `fieldset` to create a chip group.
-- Chips need to be focusable and part of the tab sequence.
-- When the chip has focus, pressing the "Space" key selects it or activates an action.
-
 {{< whats-changed-table >}}
 
 | Date       | Version | Notes                             | Contributors |

--- a/layouts/partials/menu-left.html
+++ b/layouts/partials/menu-left.html
@@ -1,3 +1,4 @@
+{{ $currentPage := . }}
 <div class="container">
   <div class="row mt-n4 d-md-none">
     <div class="col px-0">
@@ -48,7 +49,9 @@
       {{- if .Params.componentsWeb -}}
       {{ range .Site.Menus.components_web }}
       {{- if not .Params.hidden -}}
-      <li><a class="nav-link" href="{{ .URL }}">
+      <li><a
+          class="nav-link {{ if or (eq $currentPage.RelPermalink .URL) (eq $currentPage.Parent.Name .Name) }}active{{- end -}}"
+          href="{{ .URL }}">
           {{- .Name -}}
         </a></li>
       {{- end }}
@@ -58,7 +61,9 @@
       {{ if in .Params.tags "in-field" }}
       {{ range .Site.Menus.components_infield }}
       {{- if not .Params.hidden -}}
-      <li><a class="nav-link" href="{{ .URL }}">
+      <li><a
+          class="nav-link {{ if or (eq $currentPage.RelPermalink .URL) (eq $currentPage.Parent.Name .Name) }}active{{- end -}}"
+          href="{{ .URL }}">
           {{- .Name -}}
         </a></li>
       {{- end }}
@@ -82,19 +87,18 @@
       </li>
       {{- end -}}
       {{- end -}}
-<script>
-  $(function () {
-    var nav = document.getElementById("menu-left"),
-      anchor = nav.getElementsByTagName("a"),
-      current = window.location;
-    for (var i = 0; i < anchor.length; i++) {
-      if (anchor[i].href == current) {
-        anchor[i].className = "nav-link active";
-        anchor[i].setAttribute("aria-current", "page");
-      }
-    }
-  });
+</ul>
+    <script>
+      $(function () {
+        var nav = document.getElementById("menu-left"),
+          anchor = nav.getElementsByTagName("a"),
+          current = window.location;
+        for (var i = 0; i < anchor.length; i++) {
+          if (anchor[i].href == current) {
+            anchor[i].setAttribute("aria-current", "page");
+          }
+        }
+      });
 </script>
-    </ul>
-    </nav>
-    </div>
+  </nav>
+  </div>


### PR DESCRIPTION
This PR also fixes duplicate a11y section on Chips and Badges and adds dark-mode variant to In-Field Overview.

Note to see this change check: https://wonderful-hill-0a9292110-317.centralus.1.azurestaticapps.net/components/web/alerts/accessibility/ and note that 'Alerts' is bold on the left-side.