### PR TITLE
Improved Titles for Component Pages

### DIFF
--- a/content/components/in-field/_index.md
+++ b/content/components/in-field/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Components"
+title: "In-Field Components"
 weight: 1
 description: "Components are the building blocks of the design system designed with users in mind."
 componentsInField: true

--- a/content/components/web/_index.md
+++ b/content/components/web/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Components"
+title: "Components (Web)"
 weight: 1
 description: "Components are the building blocks of the design system designed with users in mind."
 componentsWeb: true

--- a/content/news/2022-12-14-sprint-book-review.md
+++ b/content/news/2022-12-14-sprint-book-review.md
@@ -31,4 +31,4 @@ In this 5-day process, each day is structured and meant to solve different piece
 
 In conclusion, *Sprint* gives superpowers to organizations and teams. It allows them to fast-forward into the future to see what kind of impact their product/future product will have on targeted customers before making any expensive commitments.
 
-[Learn more](https://www.thesprintbook.com/book)
+[Get the book.](https://www.thesprintbook.com/book)

--- a/layouts/_default/components.html
+++ b/layouts/_default/components.html
@@ -17,8 +17,10 @@
 
 <style>
   .col-12:has(.card-components),
+  .col-12:has(.card-components-web),
   .col-12:has(.card-mobile),
   .col-12:has(.card-in-field),
+  .col-12:has(.card-in-field-components),
   .col-12:has(.card-web),
   .col-12:has(.card-xr-components) {
     display: none !important;


### PR DESCRIPTION
This change the Titles of the pages in the headers to make them unique so users can see clearly which section they are in.

![image](https://user-images.githubusercontent.com/1212885/206741181-ed6e6dae-2961-4db1-aa2f-4b7ff237cecf.png)

![image](https://user-images.githubusercontent.com/1212885/206741240-24a3b2f2-6c29-48c2-897e-e8511f28ae6a.png)
