### PR TITLE
Deploy to S3, faster and safer

### DIFF
--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -18,13 +18,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - uses: actions/setup-node@v3
         with:
           node-version: 14
+          cache: npm
+
       - name: Install dependencies
-        run: npm i
+        run: npm ci
+
       - name: Build
         run: npm run build
+
       - name: Deploy
         uses: reggionick/s3-deploy@v3
         with:
@@ -32,5 +37,4 @@ jobs:
           bucket: ${{ secrets.S3_BUCKET }}
           bucket-region: us-east-1
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          no-cache: true
           invalidation: /


### PR DESCRIPTION
- Run `npm ci` instead of `npm i`
- Assets are now cached on the CDN for improved performance
- npm packages are cached for faster build-time