### PR TITLE
Fix Deploy GH Action

### DIFF
--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -22,10 +22,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
-          cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm i
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
`npm ci` doesn't work, reverting to `npm i`
