### PR TITLE
Don't hide a11y link from Mobile Tabs pages

### DIFF
--- a/content/components/mobile/tabs/_index.md
+++ b/content/components/mobile/tabs/_index.md
@@ -6,7 +6,7 @@ components: true
 component: Tabs
 images:
   - "/img/mobile/headers/tabs.png"
-tags: [mobile, usage, hide-accessibility]
+tags: [mobile, usage]
 ---
 
 _Designers should use [Segmented Controls](/components/mobile/segmented-controls/) when available due to usability issues with tabs. If that is not feasible, please follow the specifications below._

--- a/content/components/mobile/tabs/styles.md
+++ b/content/components/mobile/tabs/styles.md
@@ -6,7 +6,7 @@ components: true
 component: tabs
 images:
   - "/img/mobile/headers/tabs.png"
-tags: [mobile, styles, hide-accessibility]
+tags: [mobile, styles]
 ---
 
 ## Specifications


### PR DESCRIPTION
We have a11y page for Tabs now so we can show the a11y tab/link from:
https://modus.trimble.com/components/mobile/tabs/