### PR TITLE
Fix for color-scheme always being in dark mode

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "alpha-value-notation": null,
     "color-function-notation": null,
+    "media-feature-range-notation": null,
     "no-descending-specificity": null,
     "no-duplicate-selectors": null,
     "no-invalid-position-at-import-rule": null,

--- a/assets/styles/_theme-light.scss
+++ b/assets/styles/_theme-light.scss
@@ -1,4 +1,5 @@
 [data-theme="light"] {
+  html,
   body {
     color-scheme: light;
   }

--- a/assets/styles/styles.scss
+++ b/assets/styles/styles.scss
@@ -27,6 +27,11 @@
 @import "was-this-page-helpful";
 @import "anatomy-css";
 
+html,
+body {
+  color-scheme: light;
+}
+
 // underline links
 a {
   text-decoration: underline;


### PR DESCRIPTION
## Description

Fixes: https://github.com/trimble-oss/website-modus.trimble.com/issues/500

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Edge v112

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Existing tests pass locally with my changes
