### PR TITLE
Change to News post header template

### DIFF
--- a/assets/styles/_menu-left.scss
+++ b/assets/styles/_menu-left.scss
@@ -14,7 +14,7 @@
 }
 
 .menu-left a {
-  color: #111;
+  color: #171c1e;
 }
 
 [data-theme="dark"] {

--- a/assets/styles/_posts.scss
+++ b/assets/styles/_posts.scss
@@ -1,8 +1,11 @@
 // blog posts
 header.header-blog {
   background-size: cover;
-  padding-top: 33% !important;
-  background-position: center top;
+  min-height: 90px;
+  aspect-ratio: 21/9;
+  background-position: center;
+  border-radius: 8px;
+  max-height: 600px;
 }
 
 .share svg {

--- a/assets/styles/_theme-dark.scss
+++ b/assets/styles/_theme-dark.scss
@@ -88,4 +88,8 @@
     background-color: rgba(106, 110, 121, 0.2) !important;
     color: #f1f1f6 !important;
   }
+
+  #TableOfContents a {
+    color: #fff;
+  }
 }

--- a/assets/styles/_theme-light.scss
+++ b/assets/styles/_theme-light.scss
@@ -26,5 +26,9 @@
     display: none !important;
   }
 
+  #TableOfContents a {
+    color: #171c1e;
+  }
+
   @import "../../node_modules/@trimbleinc/modus-bootstrap/dist/modus";
 }

--- a/content/news/2023-05-21-skeletons-tiger-team.md
+++ b/content/news/2023-05-21-skeletons-tiger-team.md
@@ -5,7 +5,7 @@ description: "We are searching for contributors to join a Skeletons, Placeholder
 image: "/img/blog/headers/2023-05-22-tiger-team.jpg"
 images:
   - /img/blog/headers/2023-05-22-tiger-team.jpg
-headerBgColor: "#E69335"
+headerBgColor: "#f3f8fe"
 tags: ["tiger", "team"]
 author: Sonia Kaukonen
 blog: true

--- a/content/news/2023-06-06-modus-adoption-viewpoint.md
+++ b/content/news/2023-06-06-modus-adoption-viewpoint.md
@@ -5,7 +5,7 @@ description: "The Viewpoint team worked for past couple of years on a long-term 
 image: "/img/blog/headers/2023-06-06-modus-adoption-viewpoint.png"
 images:
   - /img/blog/headers/2023-06-06-modus-adoption-viewpoint.png
-headerBgColor: "#E69335"
+headerBgColor: "#bec8d0"
 tags: ["modus", "adoption", "viewpoint"]
 author: Dara Bedick
 blog: true

--- a/layouts/_default/blog-post.html
+++ b/layouts/_default/blog-post.html
@@ -1,8 +1,10 @@
 {{ define "main" }}
 
-<header class="container-fluid px-0 pb-5 border-bottom header-blog mt-5 mt-md-0"
-  style="background-image: url({{ .Params.Image | relURL }});{{ with .Params.headerBgColor }}background-color:{{ . }} !important;{{- end -}}">
-</header>
+<div class="pt-5 px-1 px-lg-4">
+  <header class="container pb-5 mt-5 header-blog px-4"
+    style="background-image: url({{- .Params.Image | relURL -}});{{- with .Params.headerBgColor -}}background-color:{{- . -}} !important;{{- end -}};">
+  </header>
+</div>
 
 <main class="my-5 container">
 


### PR DESCRIPTION
This change makes the header image not full-width.

Example: https://wonderful-hill-0a9292110-608.centralus.1.azurestaticapps.net/news/2023-06-06-modus-adoption-viewpoint/

![image](https://github.com/trimble-oss/website-modus.trimble.com/assets/1212885/8114e517-c48a-4da4-91fe-4117e8ade1ff)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v114

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Existing tests pass locally with my changes
