### PR TITLE
Update Content Tree Accessibility guidelines

### DIFF
--- a/content/components/web/content-tree/accessibility.md
+++ b/content/components/web/content-tree/accessibility.md
@@ -19,6 +19,6 @@ tags: [accessibility]
   - The `button` element is the only element inside the `heading` element. That is, if there are other visually persistent elements, they are not included inside the `heading` element.
 - If the accordion panel associated with an accordion header is visible, the header `button` element has `aria-expanded` set to `true`. If the panel is not visible, `aria-expanded` is set to `false`.
 - The accordion header `button` element has `aria-controls` set to the ID of the element containing the accordion panel content.
-- "Enter" or "Space" key should expand and collapse items. "Tab" key moves focus to the next focusable element; all focusable elements in the content tree should be included in the page tab sequence. "Shift" + "Tab" moves focus to the previous focusable element.
-- Avoid keyboard traps when adding components to the content tree. For example, the user expands a section, but is unable to tab to the next focusable element or to tab out of the content tree panel.
+- "Enter" or "Space" key should expand and collapse items. "Arrow" keys move focus to the next focusable element; tabbing allows the user to move to the main content on the page, and should not navigate through the content tree allowing the user to skip it.
+- Avoid keyboard traps when adding components to the content tree. For example, the user expands a section, but is unable to navigate to the next focusable element or to tab out of the content tree panel.
 - Although the content tree element passes accessibility testing, content authors are responsible for ensuring the content in the content tree is accessible.


### PR DESCRIPTION
## Description

Update about using arrow keys for focusing elements inside the content tree tabbing allows users to move to the main content of the page.

Fixes #452 

Preview: https://wonderful-hill-0a9292110-618.centralus.1.azurestaticapps.net/components/web/content-tree/accessibility/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update

## How Has This Been Tested?

Verify Accessibility section in Components(Web) - Content Tree page

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Existing tests pass locally with my changes
