### PR TITLE
Minor docs fixes

### DIFF
--- a/content/components/web/badges/_index.md
+++ b/content/components/web/badges/_index.md
@@ -89,11 +89,11 @@ Badges can be inserted into other elements.
   <div class="guide-sample">
     <button type="button" class="btn btn-outline-primary">
     Button <span class="badge badge-primary">9</span>
-    <span class="sr-only">unread messages</span>
+    <span class="sr-only visually-hidden">unread messages</span>
     </button>
     <button type="button" class="btn btn-primary">
     Button <span class="badge badge-text-tertiary">9</span>
-    <span class="sr-only">unread messages</span>
+    <span class="sr-only visually-hidden">unread messages</span>
     </button>
     <ul class="mt-3 list-group">
       <li class="list-group-item d-flex justify-content-between align-items-center">

--- a/content/components/web/cards/_index.md
+++ b/content/components/web/cards/_index.md
@@ -16,9 +16,9 @@ tags: [usage]
 
 ## Overview
 
-Cards act as container or surface for displaying relevant grouped information.  Cards can be used as a single entity or in lists or grids for browsing and are often interactive. Cards can contain a wide range of both static and interactive content. They should not be nested within other cards and cannot divide into multiple cards. The card container is the only required element in a card.
+Cards act as container or surface for displaying relevant grouped information. Cards can be used as a single entity or in lists or grids for browsing and are often interactive. Cards can contain a wide range of both static and interactive content. They should not be nested within other cards and cannot divide into multiple cards. The card container is the only required element in a card.
 
-<div class="card shadow" style="width: 18rem;">
+<div class="card" style="width: 18rem;">
   <div class="card-header">Card Header</div>
   <div class="card-body">
     <h4 class="card-title">Card Title</h4>

--- a/content/components/web/file-upload-dropzone/_index.md
+++ b/content/components/web/file-upload-dropzone/_index.md
@@ -10,6 +10,7 @@ images:
   - "/img/components/headers/file-upload-dropzone.png"
 bootstrapURL: "/components/file-upload-dropzone/"
 webComponentsURL: "https://modus-web-components.trimble.com/?path=/story/components-file-dropzone--default"
+tags: [usage]
 ---
 
 ## Overview

--- a/content/components/web/inputs/_index.md
+++ b/content/components/web/inputs/_index.md
@@ -55,7 +55,7 @@ Input fields or text fields allow users to enter text into a UI. They typically 
     </div>
   </div>
   <div class="form-group">
-    <label for="exampleFormControlSelect">Custom Select Outlined</label>
+    <label for="exampleFormControlSelect">Select</label>
     <select class="custom-select form-control" id="exampleFormControlSelect">
       <option>Option 1</option>
       <option>Option 2</option>
@@ -65,7 +65,7 @@ Input fields or text fields allow users to enter text into a UI. They typically 
     </select>
   </div>
   <div class="form-group">
-  <label for="Textarea">Normal Text Area</label>
+  <label for="Textarea">Text Area</label>
   <textarea class="form-control" id="Textarea">Some Text</textarea>
 </div>
   <button type="submit" class="btn btn-primary">Submit</button>

--- a/content/components/web/sliders/_index.md
+++ b/content/components/web/sliders/_index.md
@@ -38,7 +38,6 @@ Sliders select a numeric value or range of values by moving a handle or set of h
 - Precise amount is needed and the scale is too large to afford precise interaction with the slider.
 - Adjusting settings with any delay in providing user feedback.
 
-
 {{< whats-changed-table >}}
 
 | Date       | Version | Notes                                      | Contributors                   |

--- a/content/components/web/tooltips/styles.md
+++ b/content/components/web/tooltips/styles.md
@@ -19,7 +19,7 @@ tags: [styles]
 - The container of the tooltip text may be aligned to start, center or end.
 - Do not make the tooltip larger than the element it appears from.
 
-<img src="/img/components/tooltips-positions.svg" alt="Tooltip positions"/>
+<img src="/img/components/tooltips-positions.svg" class="img-fluid" width="800" height="300" alt="Tooltip positions"/>
 <style>
 [data-theme="dark"] img[src="/img/components/tooltips-positions.svg"] {
  content: url(/img/components/tooltips-positions-dark.svg);

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,34 +6,33 @@
   {{ partialCached "analytics" . }}
 </head>
 
-{{- if and (gt .WordCount 350 ) (not .Params.hideToc) -}}
+<body data-url="{{- .RelPermalink -}}" {{ if and (gt .WordCount 350 ) (not .Params.hideToc) -}} data-spy="scroll"
+  data-target="#TableOfContents" data-offset="126" {{- end -}} {{ if .Params.listJS }}id="listjs-body" {{- end -}}>
 
-<body data-url="{{ .RelPermalink }}" data-spy="scroll" data-target="#TableOfContents" data-offset="126"
-  {{ if .Params.listJS }}id="listjs-body" {{- end -}}>
-  {{ else }}
+  {{ partial "navbar" . }}
 
-  <body data-url="{{ .RelPermalink }}" {{ if .Params.listJS }}id="listjs-body" {{- end -}}>
-    {{- end -}}
+  {{ block "body" . }} {{ block "main" . }} {{- end -}}
+  {{- end -}}
 
-    {{ partial "navbar" . }}
+  {{ block "footer" . }} {{ partialCached "footer" . }} {{- end -}}
 
-    {{ block "body" . }} {{ block "main" . }} {{- end -}}
-    {{- end -}}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const tooltips = document.querySelectorAll('[data-toggle="tooltip"]');
+      tooltips.forEach(function (tooltip) {
+        new Tooltip(tooltip);
+      });
+    });
+  </script>
 
-    {{ block "footer" . }} {{ partialCached "footer" . }} {{- end -}}
+  {{ $scrollToTop := resources.Get "js/scroll-to-top.js" }}
+  {{ $feedback := resources.Get "js/was-this-page-helpful.js" }}
+  {{ $js := slice $scrollToTop $feedback | resources.Concat "js/app.js" | resources.Minify }}
+  <script src="{{ $js.RelPermalink }}" async></script>
+  <button type="button" aria-label="scroll to top" class="btn-to-top border-0 rounded position-fixed">
+    {{ partial "icons/modus-outlined/arrow-up.svg" (dict "class" "mt-n1 text-white opacity-50" "width" "24" "height" "24") }}
+  </button>
 
-    <script>
-      $(function () { $('[data-toggle="tooltip"]').tooltip() });
-    </script>
-
-    {{ $scrollToTop := resources.Get "js/scroll-to-top.js" }}
-    {{ $feedback := resources.Get "js/was-this-page-helpful.js" }}
-    {{ $js := slice $scrollToTop $feedback | resources.Concat "js/app.js" | resources.Minify }}
-    <script src="{{ $js.RelPermalink }}" async></script>
-    <button type="button" aria-label="scroll to top" class="btn-to-top border-0 rounded position-fixed">
-      {{ partial "icons/modus-outlined/arrow-up.svg" (dict "class" "mt-n1 text-white opacity-50" "width" "24" "height" "24") }}
-    </button>
-
-  </body>
+</body>
 
 </html>


### PR DESCRIPTION
- Base Hugo Template simplification
- Prevent Tooltips image appearing too large
- Add Usage tab active to File Upload Dropzone page
- Remove erroneous shadow from card example
- Small changes for future MB2 CSS migration

