### PR TITLE
Capitalization fixes

### DIFF
--- a/content/components/web/accordions/_index.md
+++ b/content/components/web/accordions/_index.md
@@ -58,7 +58,7 @@ Accordions come in two sizes to accommodate space availability on the page or wi
           aria-controls="codeCollapseOne"
         >
           <h6 class="mb-0">
-            Collapsible Group Item #1
+            Collapsible group item #1
           </h6>
         </div>
         <div
@@ -82,7 +82,7 @@ Accordions come in two sizes to accommodate space availability on the page or wi
           aria-controls="codeCollapseTwo"
         >
           <h6 class="mb-0">
-            Collapsible Group Item #2
+            Collapsible group item #2
           </h6>
         </div>
         <div
@@ -106,7 +106,7 @@ Accordions come in two sizes to accommodate space availability on the page or wi
           aria-controls="codeCollapseThree"
         >
           <h6 class="mb-0">
-            Collapsible Group Item #3
+            Collapsible group item #3
           </h6>
         </div>
         <div
@@ -138,7 +138,7 @@ Accordions come in two sizes to accommodate space availability on the page or wi
           aria-controls="smallCodeCollapseOne"
         >
           <h6 class="mb-0">
-            Collapsible Group Item #1
+            Collapsible group item #1
           </h6>
         </div>
         <div
@@ -162,7 +162,7 @@ Accordions come in two sizes to accommodate space availability on the page or wi
           aria-controls="smallCodeCollapseTwo"
         >
           <h6 class="mb-0">
-            Collapsible Group Item #2
+            Collapsible group item #2
           </h6>
         </div>
         <div
@@ -186,7 +186,7 @@ Accordions come in two sizes to accommodate space availability on the page or wi
           aria-controls="smallCodeCollapseThree"
         >
           <h6 class="mb-0">
-            Collapsible Group Item #3
+            Collapsible group item #3
           </h6>
         </div>
         <div

--- a/content/components/web/accordions/styles.md
+++ b/content/components/web/accordions/styles.md
@@ -43,7 +43,7 @@ tags: [styles]
           data-content="<small><b>font-size:</b> 16px<br><b>font-weight:</b> 600<br></small>"
         >
           <h5 class="mb-0">
-            Accordion Title
+            Accordion title
           </h5>
         </div>
         <div
@@ -66,7 +66,7 @@ tags: [styles]
           aria-controls="collapseTwo"
         >
           <h5 class="mb-0">
-            Accordion Title
+            Accordion title
           </h5>
         </div>
         <div
@@ -89,7 +89,7 @@ tags: [styles]
           aria-controls="collapseThree"
         >
           <h5 class="mb-0">
-            Accordion Title
+            Accordion title
           </h5>
         </div>
         <div
@@ -124,7 +124,7 @@ tags: [styles]
             aria-expanded="true"
             aria-controls="collapseOne">
             <h6 class="mb-0">
-              Accordion Title
+              Accordion title
             </h6>
           </div>
           <div
@@ -145,7 +145,7 @@ tags: [styles]
             aria-expanded="false"
             aria-controls="collapseTwo">
             <h6 class="mb-0">
-              Accordion Title
+              Accordion title
             </h6>
           </div>
           <div
@@ -166,7 +166,7 @@ tags: [styles]
             aria-expanded="false"
             aria-controls="collapseThree">
             <h6 class="mb-0">
-              Accordion Title
+              Accordion title
             </h6>
           </div>
           <div
@@ -191,7 +191,7 @@ tags: [styles]
             aria-expanded="true"
             aria-controls="collapseOne">
             <h6 class="mb-0">
-              Accordion Title
+              Accordion title
             </h6>
           </div>
           <div
@@ -212,7 +212,7 @@ tags: [styles]
             aria-expanded="false"
             aria-controls="collapseTwo">
             <h6 class="mb-0">
-              Accordion Title
+              Accordion title
             </h6>
           </div>
           <div
@@ -233,7 +233,7 @@ tags: [styles]
             aria-expanded="false"
             aria-controls="collapseThree">
             <h6 class="mb-0">
-              Accordion Title
+              Accordion title
             </h6>
           </div>
           <div

--- a/content/components/web/messages/_index.md
+++ b/content/components/web/messages/_index.md
@@ -33,7 +33,7 @@ Messages display low priority content directly on the page and are not dismissab
 
 - Providing the user with helpful, contextual information about a possible action or a set of data.
 
-#### Don’t use when
+#### Don't use when
 
 - Alerting the user of a high priority error. Instead, use an [Alert](/components/web/alerts/).
 - Alerting the user of an out-of-context event. Instead, use a [Toast](/components/web/toasts/).

--- a/content/components/web/tables/styles.md
+++ b/content/components/web/tables/styles.md
@@ -17,7 +17,7 @@ tags: [styles]
 ### Typography
 
 <!-- prettier-ignore-start -->
-| Class     | Font Size    | Font Weight   | Font Color                                                                                    | Text Transform     |
+| Class     | Font size    | Font weight   | Font color                                                                                    | Text transform     |
 | --------- | ------------ | ------------- | --------------------------------------------------------------------------------------------- | ------------------ |
 | Header    | Body-1/ 14px | SemiBold/ 600 | {{< color-preview nameL="Gray 8" hexL="#464B52" nameD="Gray 0" hexD="#E0E1E9" >}}             | Title Case         |
 | Row       | Body-1/ 14px | SemiBold/ 600 | {{< color-preview nameL="Trimble Gray" hexL="#252A2E" nameD="White" hexD="#fff" >}}           | None               |
@@ -37,7 +37,7 @@ Follow these rules, when aligning alphanumeric and numeric input types in a colu
 ### Structure
 
 <!-- prettier-ignore-start -->
-| Class            | Height | Min Width |
+| Class            | Height | Min width |
 | ---------------- | ------ | --------- |
 | Header Default   | 48px   | 16px      |
 | Header Condensed | 32px   | 16px      |
@@ -111,7 +111,7 @@ There are two categories of actions available in tables:
   - Cell Error State: When user exits out of the cell, his input will be validated and if the input is invalid, the cell borders become red to indicate an error and, while the user is in the field, the error message will also display to provide additional information about the error and how to correct it. When the user is correcting the error, the validation only runs again, when he exits the cell (not while typing in the cell).
 
 <!-- prettier-ignore-start -->
-|                   | Background                                                                              | Border (2px)                                                                                 | Cell Text |
+|                   | Background                                                                              | Border (2px)                                                                                 | Cell text |
 | ----------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------- |
 | Selected Cell     | {{< color-preview hexL="#ffffff" nameL="White" hexD="#019AEB" nameD="Highlight Blue">}} | {{< color-preview hexL="#217CBB" nameL="Blue Light" hexD="#019AEB" nameD="Highlight Blue">}} | Body 2    |
 | Invalid Cell Data | {{< color-preview hexL="#ffffff" nameL="White" hexD="#171C1E" nameD="Gray 10">}}        | {{< color-preview hex="#DA212C" name="Red">}}                                                | Body 2    |

--- a/hugo.yml
+++ b/hugo.yml
@@ -18,7 +18,7 @@ params:
 
 publishdir: "./build/"
 
-disableKinds: ["taxonomy", "taxonomyTerm", "404"]
+disableKinds: ["taxonomy", "term"]
 
 pygmentsUseClasses: true
 

--- a/layouts/shortcodes/whats-changed-table.html
+++ b/layouts/shortcodes/whats-changed-table.html
@@ -1,5 +1,5 @@
 {{ $htmlTable := .Inner | markdownify }}
 {{ $old := "<table>" }}
-{{ $new := printf "<div class=\"h5 mt-4\">What's Changed</div><table class=\"table table-whats-new border table-sm\">" }}
+{{ $new := printf "<div class=\"h5 mt-4\">What's changed</div><table class=\"table table-whats-new border table-sm\">" }}
 {{ $htmlTable := replace $htmlTable $old $new }}
 {{ $htmlTable | safeHTML }}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "autoprefixer": "10.4.14",
     "cross-env": "7.0.3",
     "htmlhint": "1.1.4",
-    "hugo-bin": "0.112.1",
+    "hugo-bin": "0.113.0",
     "list.js": "2.3.1",
     "npm-run-all": "4.1.5",
     "postcss": "8.4.27",


### PR DESCRIPTION
- Change subheaders to Sentence case (not title case)
- Update Hugo to latest version
- Remove deprecated tag from Hugo config.