### PR TITLE
Don't display placeholders in form input examples

### DIFF
--- a/content/components/web/alerts/_index.md
+++ b/content/components/web/alerts/_index.md
@@ -45,7 +45,6 @@ Alerts display in direct response to a user action (e.g. clicking the Submit but
                   class="form-control"
                   id="exampleInputEmail1"
                   aria-describedby="emailHelp"
-                  placeholder="Enter email"
                   autocomplete="email"
                 />
               </div>
@@ -55,7 +54,6 @@ Alerts display in direct response to a user action (e.g. clicking the Submit but
                   type="password"
                   class="form-control"
                   id="exampleInputPassword1"
-                  placeholder="Password"
                   autocomplete="off"
                 />
               </div>

--- a/content/components/web/inputs/_index.md
+++ b/content/components/web/inputs/_index.md
@@ -23,12 +23,12 @@ Input fields or text fields allow users to enter text into a UI. They typically 
 <form>
   <div class="form-group">
     <label for="RegularInput">Regular Input</label>
-    <input class="form-control" id="RegularInput" placeholder="Placeholder Text">
+    <input class="form-control" id="RegularInput">
   </div>
   <div class="form-group">
     <label for="Input2">Input with icon on right</label>
     <div class="input-with-icon-right">
-      <input class="form-control" placeholder="Placeholder Text" id="Input2">
+      <input class="form-control" id="Input2">
       <div class="input-icon">
         <i class="modus-icons notranslate" aria-hidden="true">visibility</i>
       </div>
@@ -37,7 +37,7 @@ Input fields or text fields allow users to enter text into a UI. They typically 
   <div class="form-group">
     <label for="Input3">Input with icon on left</label>
     <div class="input-with-icon-left">
-      <input class="form-control" placeholder="Placeholder Text" id="Input3">
+      <input class="form-control" id="Input3">
       <div class="input-icon">
         <i class="modus-icons notranslate" aria-hidden="true">search</i>
       </div>
@@ -46,7 +46,7 @@ Input fields or text fields allow users to enter text into a UI. They typically 
   <div class="form-group">
     <label for="Input4">Input with a button</label>
     <div class="input-group">
-      <input class="form-control" placeholder="Placeholder Text" id="Input4">
+      <input class="form-control" id="Input4">
       <div class="input-group-append">
         <button class="btn btn-outline-secondary" type="button">
           Go

--- a/content/components/web/inputs/styles.md
+++ b/content/components/web/inputs/styles.md
@@ -33,10 +33,8 @@ There are two sizes of input fields defined:
     <tr>
       <th scope="row">Default</th>
       <td class="anatomy-cell">
-        <input class="form-control mb-2" placeholder="Placeholder text" style="padding-left: 8px; padding-right: 8px;">
         <input
           class="form-control anatomy-display-static mb-5"
-          placeholder="Default Input"
           value="Default Input"
           style="padding-left: 8px; padding-right: 8px;"
         />
@@ -48,13 +46,7 @@ There are two sizes of input fields defined:
       <th scope="row">Large</th>
       <td class="anatomy-cell">
         <input
-          class="form-control form-control-lg mb-2"
-          placeholder="Placeholder text"
-          style="padding-left: 16px; padding-right: 16px;"
-        />
-        <input
           class="form-control form-control-lg anatomy-display-static mb-5"
-          placeholder="Large Input"
           value="Large Input"
           style="padding-left: 16px; padding-right: 16px;"
         />
@@ -98,7 +90,7 @@ There are two sizes of input fields defined:
     </div>
     <div class="form-group">
       <label for="disabledInput">Disabled Input</label>
-      <input class="form-control" id="disabledInput" disabled placeholder="Disabled" />
+      <input class="form-control" id="disabledInput" disabled value="Disabled" />
     </div>
     <div class="form-group">
       <label for="ReadonlyInput">Readonly Input</label>


### PR DESCRIPTION
We don't encourage using placeholders due to potential accessibility issues so we should not use them in our examples