### PR TITLE
Update headers to trimble-blue

### DIFF
--- a/assets/styles/_article.scss
+++ b/assets/styles/_article.scss
@@ -14,6 +14,11 @@ h5:hover .header-link {
   transition: 0.3s all;
 }
 
+main article h3.h2,
+main article h2.h1 {
+  color: var(--bs-blue); // Trimble Blue
+}
+
 // title of article shouldn't have margin-top
 main article h2.h1:first-of-type {
   margin-top: 0 !important;

--- a/assets/styles/_article.scss
+++ b/assets/styles/_article.scss
@@ -16,7 +16,14 @@ h5:hover .header-link {
 
 main article h3.h2,
 main article h2.h1 {
-  color: var(--bs-blue); // Trimble Blue
+  color: #004f83; // Trimble Blue Dark
+}
+
+[data-bs-theme="dark"] {
+  main article h3.h2,
+  main article h2.h1 {
+    color: #dcedf9; // Pale Blue
+  }
 }
 
 // title of article shouldn't have margin-top


### PR DESCRIPTION
This changes the headers within the docs from the same color as is used for body text to:
- `#004f83` for light mode
- `#dcedf9` for dark mode

I think it's a great improvement - let me know what you think!

Preview: https://wonderful-hill-0a9292110-830.centralus.1.azurestaticapps.net/foundations/voice-and-tone/