### PR TITLE
Markdown formatting fix

### DIFF
--- a/content/components/web/dropdowns/accessibility.md
+++ b/content/components/web/dropdowns/accessibility.md
@@ -16,7 +16,8 @@ tags: [accessibility]
 - When the menu is displayed, the element with role `button` has `aria-expanded` set to `true`. When the menu is hidden, it is recommended that `aria-expanded` is not present. If `aria-expanded` is specified when the menu is hidden, it is set to `false` .
 - The element that contains the menu items displayed by activating the button has role `menu`.
 - Optionally, the element with role `button` has a value specified for `aria-controls` that refers to the element with role `menu`.
-- With focus on the button, "Enter" or "Space" opens the menu and places focus on the first menu item. Up and down arrows move focus through menu items.
+- With focus on the button, <kbd>Enter</kbd> or <kbd>Space</kbd> opens the menu and places focus on the first menu item. Up and down arrows move focus through menu items.
+- Pressing <kbd>Escape</kbd> closes the menu and returns focus to the button.
 
 ### Modus Bootstrap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "bootstrap-print-css": "1.0.1",
         "cross-env": "7.0.3",
         "htmlhint": "1.1.4",
-        "hugo-bin": "0.123.1",
+        "hugo-bin": "0.123.2",
         "list.js": "2.3.1",
         "npm-run-all": "4.1.5",
         "popover-css-inspector": "1.0.0-beta14",
@@ -2849,9 +2849,9 @@
       }
     },
     "node_modules/hugo-bin": {
-      "version": "0.123.1",
-      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.123.1.tgz",
-      "integrity": "sha512-YENQPHxg8jFvn5KyTrqUj+mXwGHNJzelc8TzzJ1l6Cm6ZSJsl38mdEKvejA8J1146h8Y6a2m6q6TsSx/5g3HRg==",
+      "version": "0.123.2",
+      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.123.2.tgz",
+      "integrity": "sha512-HxKrHHso1PpXMOoZbAmopCqsYzdL3oUUR+/NTBdrhAOZFsKGaP1abLdJgu9GUyhUq+gYQOtDUtpB9wjoDyv6GQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bootstrap-print-css": "1.0.1",
     "cross-env": "7.0.3",
     "htmlhint": "1.1.4",
-    "hugo-bin": "0.123.1",
+    "hugo-bin": "0.123.2",
     "list.js": "2.3.1",
     "npm-run-all": "4.1.5",
     "popover-css-inspector": "1.0.0-beta14",


### PR DESCRIPTION
- Add comment that `Escape` should close the dropdown. REF: https://www.w3.org/WAI/ARIA/apg/patterns/menubar/#:~:text=Close%20the%20menu%20that%20contains%20focus%20and%20return%20focus%20to%20the%20element%20or%20context%2C%20e.g.%2C%20menu%20button%20or%20parent%20menuitem%2C%20from%20which%20the%20menu%20was%20opened.