### PR TITLE
Alerts: Add example alert description

### DIFF
--- a/content/components/web/alerts/styles.md
+++ b/content/components/web/alerts/styles.md
@@ -105,6 +105,14 @@ document.addEventListener('DOMContentLoaded', function() {
       <button type="button" class="btn-close" aria-label="Close">
       </button>
     </div>
+    <div class="alert alert-primary d-flex align-items-top alert-dismissible fade show" role="alert">
+      <i class="modus-icons notranslate flex-shrink-0 me-2" aria-hidden="true">warning</i>
+      <div class="mb-0">An example alert with a dismiss icon
+       <p class="mb-0 fw-normal">This alert includes an example alert description</p>
+      </div>
+      <button type="button" class="btn-close" aria-label="Close">
+      </button>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
Add a simple alert with description:

![image](https://github.com/user-attachments/assets/fca1a9e6-5628-4ca7-ad81-18496d5da3c4)

PREVIEW:

https://deploy-preview-972--modus-styleguide.netlify.app/components/web/alerts/styles/#examples
