### PR TITLE
Rename wizard docs to stepper and update aliases

### DIFF
--- a/content/components/web/stepper/_index.md
+++ b/content/components/web/stepper/_index.md
@@ -9,7 +9,7 @@ images:
 tags:
   - usage
 aliases:
-  - "/components/web/stepper/"
+  - "/components/web/wizard/"
   - "/components/web/wizards/"
 ---
 

--- a/content/components/web/stepper/accessibility.md
+++ b/content/components/web/stepper/accessibility.md
@@ -9,10 +9,12 @@ hideToc: true
 tags:
   - accessibility
   - search_exclude
+aliases:
+  - "/components/web/wizard/accessibility/"
+  - "/components/web/wizards/accessibility/"
 ---
 
 ## Accessibility
-
 
 If possible, the first step of a form should explain how many steps will follow.
 Each step should inform the user about the progress they are making.
@@ -28,11 +30,12 @@ Each step should inform the user about the progress they are making.
    - a. Hide unlabeled segments. There is no content inside the segments when labels aren’t used, so it is safe to add `aria-hidden="true"` to the element
 9. The progress lines connecting the steps are pure aesthetic and don’t need attributes.
 10. Keyboard shortcuts:
-   - a. <kbd>Shift</kbd> + <kbd>Tab</kbd> = Focuses previous link
-   - b. <kbd>Tab</kbd> = Focuses next link
-   - c. <kbd>Home</kbd> = Focuses first link
-   - d. <kbd>End</kbd>	= Focuses last link
-   - e. <kbd>Space</kbd> / <kbd>Enter</kbd>	= Activates the currently focused link
+
+- a. <kbd>Shift</kbd> + <kbd>Tab</kbd> = Focuses previous link
+- b. <kbd>Tab</kbd> = Focuses next link
+- c. <kbd>Home</kbd> = Focuses first link
+- d. <kbd>End</kbd> = Focuses last link
+- e. <kbd>Space</kbd> / <kbd>Enter</kbd> = Activates the currently focused link
 
 <style>
   main ul:last-of-type {

--- a/content/components/web/stepper/styles.md
+++ b/content/components/web/stepper/styles.md
@@ -8,6 +8,9 @@ images:
   - "/img/components/headers/wizard.png"
 tags:
   - styles
+aliases:
+  - "/components/web/wizard/styles/"
+  - "/components/web/wizards/styles/"
 ---
 
 <style>
@@ -201,7 +204,6 @@ Use inline labels with vertical layouts
     <button type="button" class="btn btn-primary pe-none">Next</button>
   </div>
 </div>
-
 
 - The footer is placed at the bottom of a page or modal
 - It has to contain a wizard pager and title of the step


### PR DESCRIPTION
Renamed wizard documentation files to stepper and updated internal aliases to reflect the new naming. Added accessibility and styles aliases for backward compatibility and improved formatting in accessibility documentation.